### PR TITLE
jsonToObj obsoleted in JSON 2.x

### DIFF
--- a/lib/WebService/PagerDuty/Response.pm
+++ b/lib/WebService/PagerDuty/Response.pm
@@ -32,7 +32,7 @@ sub new {
         $options->{errors}  = undef;
 
         try {
-            $options->{data} = jsonToObj( $response->content() ) if $response->content();
+            $options->{data} = from_json( $response->content() ) if $response->content();
         }
         otherwise {
             my $error = shift;


### PR DESCRIPTION
Hi, I tried this module and failed because the version of my JSON module is 2.59.
Would you mind if WebService::PagerDuty supports newer module?
