### PR TITLE
all_schedules method to return active schedules

### DIFF
--- a/lib/WebService/PagerDuty/Response.pm
+++ b/lib/WebService/PagerDuty/Response.pm
@@ -16,6 +16,7 @@ my @all_options = qw/
   incident_key
   total limit offset
   entries
+  schedules
   data
   /;
 

--- a/lib/WebService/PagerDuty/Schedules.pm
+++ b/lib/WebService/PagerDuty/Schedules.pm
@@ -37,6 +37,18 @@ sub entries {
 }
 *list = \&entries;
 
+sub all_schedules {
+  my ( $self, %params ) = @_;
+
+    return WebService::PagerDuty::Request->new->get_data(
+        url      => URI->new( $self->url . '/' ),
+        user     => $self->user,
+        password => $self->password,
+        api_key  => $self->api_key,
+        params   => \%params,
+    );
+}
+
 1;
 
 =head1 NAME
@@ -54,6 +66,17 @@ WebService::PagerDuty::Schedules - A schedules object
 
 This class represents a basic schedules object, to get entries
 of existing schedules.
+
+=head1 METHODS
+
+=head2 all_schedules
+
+  my $response = $schedules->all_schedules;
+
+  Returns a response containing a "schedules" attribute, an array reference
+  of all schedules defined for your account.
+
+  https://developer.pagerduty.com/documentation/rest/schedules/list
 
 =head1 SEE ALSO
 

--- a/xt/author/31-schedules.t
+++ b/xt/author/31-schedules.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use lib './t/lib';
-use Test::More tests => 19;
+use Test::More tests => 22;
 use POSIX qw/ strftime /;
 
 use WebService::PagerDuty;
@@ -17,20 +17,17 @@ our $pd_schedule_id;
 
 my $pager_duty = WebService::PagerDuty->new(
     subdomain => $pd_subdomain,
-    user      => $pd_user,
-    password  => $pd_password,
+    api_key   => $pd_api_key,
 );
 
 isa_ok( $pager_duty, 'WebService::PagerDuty', 'Created WebService::PagerDuty object have correct class' );
 is( $pager_duty->subdomain, $pd_subdomain, 'Subdomain in PagerDuty object is correct' );
-is( $pager_duty->user,      $pd_user,      'User in PagerDuty object is correct' );
-is( $pager_duty->password,  $pd_password,  'Password in PagerDuty object is correct' );
+is( $pager_duty->api_key,   $pd_api_key,   'API Key in PagerDuty object is correct' );
 
 my $schedules = $pager_duty->schedules();
 isa_ok( $schedules, 'WebService::PagerDuty::Schedules', 'Created WebService::PagerDuty::Schedules object have correct class' );
 ok( $schedules->url, 'URL in Schedules object is not empty' );
-is( $schedules->user,     $pd_user,     'User in Schedules object is correct' );
-is( $schedules->password, $pd_password, 'Password in Schedules object is correct' );
+is( $schedules->api_key,  $pd_api_key,  'API Key in Schedules object is correct' );
 
 my $since = `date --date '-1 month' '+%Y-%m-%dT00:00Z'`;    # ISO 8601 required
 my $until = `date --date '+1 month' '+%Y-%m-%dT00:00Z'`;    # ISO 8601 required
@@ -40,6 +37,7 @@ my $list = $schedules->list(
     since       => $since,
     until       => $until,
 );
+
 ok( $list, 'We got non-empty response (list)' );
 isa_ok( $list, 'WebService::PagerDuty::Response', 'Returned WebService::PagerDuty::Response object have correct class (list)' );
 is( $list->status, 'success', 'Response should be successfull (list)' );
@@ -54,3 +52,10 @@ ok( $list->total >= @{ $list->entries }, 'Count of entries in response looks goo
 my $good_entries = [ map { exists( $_->{start} ) && exists( $_->{end} ) && exists( $_->{user} ) ? (1) : () } @{ $list->entries } ];
 ok( @$good_entries == @{ $list->entries }, 'Each entry in response have all needed fields (list)' );
 
+my $all_schedules = $schedules->all_schedules;
+
+cmp_ok( ref( $all_schedules->schedules ),      'eq', 'ARRAY', 'Response schedules is an array ref (all_schedules)' );
+cmp_ok( ref( $all_schedules->schedules->[0] ), 'eq', 'HASH', 'Schedule[0] is a hash reference (all_schedules)');
+cmp_ok( ref( $all_schedules->schedules->[0] ), 'eq', 'HASH', 'Schedule[0] is a hash reference (all_schedules)');
+ok( $all_schedules->schedules->[0]{id},   'Schedule[0] has an id' );
+ok( $all_schedules->schedules->[0]{name}, 'Schedule[0] has a name' );


### PR DESCRIPTION
I wanted a method to support the retrieval of all schedules. Let me know if this works for you or if there are any changes you'd like to see.

I added a few tests to the "xt" tests which pass when I create a new PagerDuty account and point t/lib/config.pl at my new account. (They fail with the checked in one because that's long since expired.) 
